### PR TITLE
Floating monster HUD

### DIFF
--- a/style.css
+++ b/style.css
@@ -534,3 +534,12 @@ textarea {
   width: 100%;
   background: var(--danger-color);
 }
+
+/* Floating monster HUD */
+#monster-hud {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  z-index: 10002;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- make the monster HUD appear as a floating widget so it's visible alongside the timers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d28abf3a88322a9d4c899e5f9faed