### PR TITLE
Add customizable dungeon missions

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,20 @@
             </div>
           </div>
 
+          <div id="mission-manager" class="manager-section mb-4">
+            <div class="row g-2 align-items-center">
+              <div class="col-auto">
+                <select id="mission-select" class="form-select">
+                  <option value="">Seleccionar Misión</option>
+                </select>
+              </div>
+              <div class="col-auto">
+                <button id="new-mission-btn" class="btn btn-primary">Nueva Misión</button>
+              </div>
+              <div class="col-12" id="mission-desc"></div>
+            </div>
+          </div>
+
           <div id="notes-section" class="mb-4">
             <h2>Notas del Ensayo</h2>
             <textarea id="essay-notes" class="form-control" rows="5" placeholder="Escribe tus ideas, enlaces o recordatorios aquí..."></textarea>


### PR DESCRIPTION
## Summary
- support default and custom missions with rooms
- add mission selector in UI
- allow creating new missions via prompts
- handle monsters sequentially through dungeon rooms

## Testing
- `node --check app.js`
- `node --check assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_688d2c424f3483229a3dbbe111fb605d